### PR TITLE
Allow customisation of field group headings shown on WooCommerce checkout pages

### DIFF
--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -73,7 +73,7 @@ function wc4bp_custom_checkout_field( $checkout ) {
 add_filter( 'wc4bp_custom_checkout_field_group_heading', 'wc4bp_custom_checkout_group_heading', 10, 2 );
 
 function wc4bp_custom_checkout_group_heading( $value, $group_name ) {
-    return $group_name . ' INFORMATION';
+    return sprintf( __( '%s INFORMATION' ), $group_name );
 }
 
 /**

--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -37,7 +37,8 @@ function wc4bp_custom_checkout_field( $checkout ) {
                         echo '<div class="wc4bp_custom_checkout_fields_group" id="wc4bp_checkout_field_group_'.$group_id.'">';
                     }
                     if( $display_group_name ){
-                        echo '<h4>' . $field_attr['group_name'] . ' INFORMATION</h4>';
+                        $group_name = $field_attr['group_name'];
+                        echo '<h4>' . apply_filters( 'wc4bp_custom_checkout_field_group_heading', $group_name, $group_name ) . '</h4>';
                         $display_group_name = false;
                     }
                     $row_class = 'form-row';
@@ -64,6 +65,15 @@ function wc4bp_custom_checkout_field( $checkout ) {
         }
     }
 
+}
+
+/**
+ * Filter heading text produced for each field group on the checkout page
+ */
+add_filter( 'wc4bp_custom_checkout_field_group_heading', 'wc4bp_custom_checkout_group_heading', 10, 2 );
+
+function wc4bp_custom_checkout_group_heading( $value, $group_name ) {
+    return $group_name . ' INFORMATION';
 }
 
 /**


### PR DESCRIPTION
I was working on a project where I needed to customise the field group headings on the checkout page. For now, I am using my own fork of the wc4bp-xprofile plugin, but wanted to include the changes in a PR so that others may benefit from the changes.

The PR adds support for two levels of customisation of the field group headings on the checkout page. The first is through a filter, allowing a plugin or theme to register a hook function that can alter the string before it is displayed. The new filter is called 'wc4bp_custom_checkout_field_group_heading'.

The second is through WordPress' built-in i18n functionality (i.e. the __ function). This is achieved using a default hook function for the 'wc4bp_custom_checkout_field_group_heading' filter. The translated string is used as the format for sprintf, so that the structure of the heading text can be changed via a translation file.
