### PR TITLE
Allow visibility of Xprofile field groups to depend on products or categories in cart

### DIFF
--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -26,6 +26,10 @@ function wc4bp_custom_checkout_field( $checkout ) {
 
         foreach($fields as $field_id => $field_attr){
 
+            if ( ! apply_filters( 'wc4bp_custom_checkout_field_group_visibility', true, $group_id ) ) {
+                continue;
+            }
+
             if( ( ! empty( $billing ) && array_search( $field_id, $billing )) || ( ! empty( $shipping ) && array_search( $field_id, $shipping) ) )
                 continue;
 

--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -81,6 +81,110 @@ function wc4bp_custom_checkout_group_heading( $value, $group_name ) {
 }
 
 /**
+ * Filter the potential visibility of each field group on the checkout page
+ */
+add_filter( 'wc4bp_custom_checkout_field_group_visibility', 'wc4bp_custom_checkout_field_group_visibility', 10, 2 );
+
+/**
+ * Default hook to determine visibility of Xprofile field groups on the checkout page
+ *
+ * Whether or not a group is visible can be altered based on two kinds of cart criteria:
+ *
+ * The first case is based on the individual products in the user's cart. If the user's cart contains at least one
+ * item from a set of products, then the Xprofile group will be made visible. By default, groups do not require any
+ * particular product to be present, but this can be changed via the 'wc4bp_wc_products_that_allow_group_visibility'
+ * filter.
+ *
+ * The second case is based on the *categories* of products in the cart. If the cart contains a product belonging to at
+ * least one of a particular set of categories, then the Xprofile group will be made visible. By default, groups do not
+ * require any particular category to be present. As with the product-only case above, this behaviour can be changed
+ * via a filter called 'wc4bp_wc_categories_that_allow_group_visibility'.
+ *
+ * If neither of this criteria are set (i.e. both filters return \c false), then the group will be visible.
+ */
+function wc4bp_custom_checkout_field_group_visibility( $visible, $group_id ) {
+    if ( ! $visible ) {
+        return false;
+    }
+
+    // Re-used across multiple groups
+    static $cart = null;
+    static $products_in_cart = null;
+    static $product_categories_in_cart = null;
+
+    // Check whether the group requires at least one of a particular set of products is in the cart
+    $products_for_visibility = apply_filters( 'wc4bp_wc_products_that_allow_group_visibility', false, $group_id );
+    if ( is_array( $products_for_visibility ) && count( $products_for_visibility ) > 0 ) {
+        if ( ! isset( $products_in_cart ) ) {
+            if ( ! isset( $cart ) ) {
+                $cart = WC()->cart->get_cart();
+            }
+            $products_in_cart = wc4bp_get_all_products_in_cart( $cart );
+        }
+
+        return count( array_intersect( array_keys( $products_in_cart ), $products_for_visibility ) ) > 0;
+    }
+
+    // Check whether the group requires that at least one product of a particular set of categories is in the cart
+    $categories_for_visibility = apply_filters( 'wc4bp_wc_categories_that_allow_group_visibility', false, $group_id );
+    if ( is_array( $categories_for_visibility ) && count( $categories_for_visibility ) > 0 ) {
+        if ( ! isset( $product_categories_in_cart ) ) {
+            if ( ! isset( $products_in_cart ) ) {
+                if ( ! isset( $cart ) ) {
+                    $cart = WC()->cart->get_cart();
+                }
+                $products_in_cart = wc4bp_get_all_products_in_cart( $cart );
+            }
+            $product_categories_in_cart = wc4bp_get_categories_for_products( $products_in_cart );
+        }
+
+        return count( array_intersect( array_keys( $product_categories_in_cart ), $categories_for_visibility ) ) > 0;
+    }
+
+    return true;
+}
+
+/**
+ * Return array containing a WC_Product for each unique product in the cart, indexed by product ID
+ */
+function wc4bp_get_all_products_in_cart( $cart ) {
+    $products = array();
+
+    foreach ( $cart as $cart_item_key => $values ) {
+        if ( isset( $values['data'] ) ) {
+            $product_data = $values['data'];
+            if ( $product_data instanceof WC_Product ) {
+                $products[ $product_data->id ] = $product_data;
+            }
+        }
+    }
+
+    return $products;
+}
+
+/**
+ * Return array containing a WP_Term for each unique category in an array of products, indexed by category ID
+ */
+function wc4bp_get_categories_for_products( $products ) {
+    $categories = array();
+
+    foreach ( $products as $product_id => $product ) {
+        if ( $product instanceof WC_Product ) {
+            $terms = get_the_terms( $product->ID, 'product_cat' );
+            if ( ! empty( $terms ) ) {
+                foreach ( $terms as $term ) {
+                    if ( $term instanceof WP_Term ) {
+                        $categories[ $term->ID ] = $term;
+                    }
+                }
+            }
+        }
+    }
+
+    return $categories;
+}
+
+/**
  * Update the field for the checkout to include Woocommerce classes and pattern
  */
 add_filter('bp_xprofile_field_edit_html_elements', 'wc4bp_woo_class_for_xprofile_checkout_fields');

--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -170,11 +170,11 @@ function wc4bp_get_categories_for_products( $products ) {
 
     foreach ( $products as $product_id => $product ) {
         if ( $product instanceof WC_Product ) {
-            $terms = get_the_terms( $product->ID, 'product_cat' );
+            $terms = get_the_terms( $product->id, 'product_cat' );
             if ( ! empty( $terms ) ) {
                 foreach ( $terms as $term ) {
                     if ( $term instanceof WP_Term ) {
-                        $categories[ $term->ID ] = $term;
+                        $categories[ $term->term_id ] = $term;
                     }
                 }
             }

--- a/includes/wc4bp-xprofile-checkout.php
+++ b/includes/wc4bp-xprofile-checkout.php
@@ -114,7 +114,8 @@ function wc4bp_custom_checkout_field_group_visibility( $visible, $group_id ) {
 
     // Check whether the group requires at least one of a particular set of products is in the cart
     $products_for_visibility = apply_filters( 'wc4bp_wc_products_that_allow_group_visibility', false, $group_id );
-    if ( is_array( $products_for_visibility ) && count( $products_for_visibility ) > 0 ) {
+    $has_product_requirements = is_array( $products_for_visibility ) && count( $products_for_visibility ) > 0;
+    if ( $has_product_requirements ) {
         if ( ! isset( $products_in_cart ) ) {
             if ( ! isset( $cart ) ) {
                 $cart = WC()->cart->get_cart();
@@ -122,12 +123,15 @@ function wc4bp_custom_checkout_field_group_visibility( $visible, $group_id ) {
             $products_in_cart = wc4bp_get_all_products_in_cart( $cart );
         }
 
-        return count( array_intersect( array_keys( $products_in_cart ), $products_for_visibility ) ) > 0;
+        if ( count( array_intersect( array_keys( $products_in_cart ), $products_for_visibility ) ) > 0 ) {
+            return true;
+        }
     }
 
     // Check whether the group requires that at least one product of a particular set of categories is in the cart
     $categories_for_visibility = apply_filters( 'wc4bp_wc_categories_that_allow_group_visibility', false, $group_id );
-    if ( is_array( $categories_for_visibility ) && count( $categories_for_visibility ) > 0 ) {
+    $has_category_requirements = is_array( $categories_for_visibility ) && count( $categories_for_visibility ) > 0;
+    if ( $has_category_requirements ) {
         if ( ! isset( $product_categories_in_cart ) ) {
             if ( ! isset( $products_in_cart ) ) {
                 if ( ! isset( $cart ) ) {
@@ -138,10 +142,12 @@ function wc4bp_custom_checkout_field_group_visibility( $visible, $group_id ) {
             $product_categories_in_cart = wc4bp_get_categories_for_products( $products_in_cart );
         }
 
-        return count( array_intersect( array_keys( $product_categories_in_cart ), $categories_for_visibility ) ) > 0;
+        if ( count( array_intersect( array_keys( $product_categories_in_cart ), $categories_for_visibility ) ) > 0 ) {
+            return true;
+        }
     }
 
-    return true;
+    return ! $has_product_requirements && ! $has_category_requirements;
 }
 
 /**


### PR DESCRIPTION
This PR allows the visibility of Xprofile field groups on the checkout page to depend on certain products (or categories) being present in a user's cart.

An example of how this could be useful is an online store that sells a mix of physical products and memberships/subscriptions - when a membership or subscription product is present in the cart, you could require the user to fill out additional BuddyPress Xprofile fields.

This change introduces three new filters:
- `wc4bp_custom_checkout_field_group_visibility`
- `wc4bp_wc_products_that_allow_group_visibility`
- `wc4bp_wc_categories_that_allow_group_visibility`

The `wc4bp_custom_checkout_field_group_visibility` filter allows the visibility of a group to be altered based on any criteria. By default, it is hooked by a function that looks at the user's cart and makes the group visible if its contents overlap with a set of products or categories.

The actual products or categories that make a group visible can be configured using the `wc4bp_wc_products_that_allow_group_visibility` and `wc4bp_wc_categories_that_allow_group_visibility` filters. These filters both use the group ID as an argument. They return false by default, which means that the group will always be visible, but can be hooked to return an array of product IDs or category IDs, respectively.

**Additional notes**

This is really a proof-of-concept for a feature that would be really nice to add to the UI. By allowing a site admin to set the required products or categories for a group on the wc4bp-xprofile options page, this entire feature could be controlled via the WordPress Dashboard.
