### PR TITLE
Implement XProfile group conditional visibility feature in admin interface

### DIFF
--- a/admin/admin-xprofile-ajax.php
+++ b/admin/admin-xprofile-ajax.php
@@ -1,0 +1,47 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * AJAX endpoint to retrieve a list of categories with names containing a given search term
+ */
+function wc4bp_xprofile_search_categories() {
+	global $wpdb;
+
+	ob_start();
+
+	check_ajax_referer( 'search-categories', 'security' );
+
+	$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
+	if ( empty( $term ) ) {
+		die();
+	}
+
+	$like_term = '%' . $wpdb->esc_like( $term ) . '%';
+
+	$query = $wpdb->prepare(
+		"SELECT terms.term_id, terms.name FROM {$wpdb->terms} terms " .
+		"JOIN {$wpdb->term_taxonomy} taxonomy ON terms.term_id = taxonomy.term_id " .
+		"WHERE terms.name LIKE %s AND taxonomy.taxonomy = 'product_cat'",
+		$like_term );
+
+	if ( ! empty( $_GET['limit'] ) ) {
+		$query .= " LIMIT " . intval( $_GET['limit'] );
+	}
+
+	$terms = $wpdb->get_results( $query );
+
+	$found_categories = array();
+
+	if ( ! empty( $terms ) ) {
+		foreach ( $terms as $term ) {
+			$found_categories[ $term->term_id ] = rawurldecode( $term->name );
+		}
+	}
+
+	wp_send_json( $found_categories );
+}
+
+add_action( 'wp_ajax_wc4bp_xprofile_search_categories', 'wc4bp_xprofile_search_categories' );

--- a/admin/admin-xprofile-util.php
+++ b/admin/admin-xprofile-util.php
@@ -1,0 +1,62 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Retrieve product names for a list of product IDs
+ */
+function wc4bp_xprofile_fetch_product_names( $product_ids ) {
+	$product_data = array();
+
+	foreach ( $product_ids as $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( is_object( $product ) ) {
+			$product_data[ $product_id ] = wp_kses_post( html_entity_decode(
+				$product->get_formatted_name(), ENT_QUOTES, get_bloginfo( 'charset' ) ) );
+		}
+	}
+
+	return $product_data;
+}
+
+/**
+ * Retrieve category names for a list of category IDs
+ */
+function wc4bp_xprofile_fetch_category_names( $category_ids ) {
+	$category_data = array();
+
+	foreach ( $category_ids as $category_id ) {
+		$term = get_term( $category_id );
+		if ( is_object( $term ) && $term->taxonomy == 'product_cat' ) {
+			$category_data[ $category_id ] = wp_kses_post( html_entity_decode(
+				$term->name, ENT_QUOTES, get_bloginfo( 'charset' ) ) );
+		}
+	}
+
+	return $category_data;
+}
+
+/**
+ * Check whether a particular XProfile group exists
+ */
+function wc4bp_xprofile_group_exists( $group_id ) {
+	$group = BP_XProfile_Group::get( array( 'profile_group_id' => $group_id ) );
+
+	// empty() called on variable for compatibility with PHP 5.2.x
+	return ! empty( $group );
+}
+
+/**
+ * Create or re-use a nonce with the given name
+ */
+function wc4bp_xprofile_get_nonce( $name ) {
+	static $nonces = array();
+
+	if ( isset( $nonces[ $name ] ) ) {
+		return $nonces[ $name ];
+	}
+
+	return $nonces[ $name ] = wp_create_nonce( $name );
+}

--- a/assets/css/admin-xprofile.css
+++ b/assets/css/admin-xprofile.css
@@ -1,0 +1,102 @@
+.wc4bp-conditional-visibility-container {
+    border: 1px solid rgb(221, 221, 221);
+    font-size: 14px;
+    margin-top: 1.5em;
+    border-radius: 3px;
+    margin-bottom: 0.5em;
+}
+
+.wc4bp-conditional-visibility-container h2 {
+    border-bottom: 1px solid #eee;
+    font-family: "Open Sans", sans-serif;
+    font-weight: 600;
+    padding: 8px 12px;
+    margin: 0;
+    line-height: 1.4;
+}
+
+.wc4bp-conditional-visibility-container h2 span {
+    font-size: 15px;
+}
+
+.wc4bp-conditional-visibility-container .fields {
+    padding: 13px 16px 8px 15px;
+    font-size: 13px;
+}
+
+.wc4bp-conditional-visibility-container .fields .field.cv-enabled {
+    margin-bottom: 12px;
+}
+
+.wc4bp-conditional-visibility-container .fields .field.cv-enabled label span {
+    display: inline-block;
+    max-width: calc(100% - 40px);
+    position: relative;
+    top: 1px;
+    left: 2px;
+    vertical-align: top;
+}
+
+.wc4bp-conditional-visibility-container .fields .field.cv-products,
+.wc4bp-conditional-visibility-container .fields .field.cv-categories {
+    margin-left: 27px;
+}
+
+.wc4bp-conditional-visibility-container .fields .field.disabled label {
+    color: #999;
+    cursor: default;
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search.select2-container {
+    margin: 10px 0;
+    border-radius: 2px;
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices {
+    background: #fff;
+    border-radius: 2px;
+    box-shadow: inset 0 1px 2px rgba( 0, 0, 0, 0.07 );
+    -webkit-box-shadow: inset 0 1px 2px rgba( 0, 0, 0, 0.07 );
+    min-height: 32px;
+    padding: 3px 5px 1px 0;
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices li.select2-search-choice {
+    margin-top: 2px;
+    height: 16px;
+}
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices li.select2-search-field {
+    font-size: 14px;
+    line-height: 16px;
+    left: 2px;
+    padding-bottom: 5px;
+    position: relative;
+    top: 3px;
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices li.select2-search-field input {
+    padding: 5px 0 5px 4px;
+    top: -2px;
+    position: relative;
+}
+
+.wc4bp-conditional-visibility-container .fields .field.disabled .wc-search ul.select2-choices li.select2-search-field input {
+    color: #aaa !important;
+}
+
+.wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices a.select2-search-choice-close {
+    top: 6px;
+    transition-property: none;
+    transition-duration: 0s;
+}
+
+/* Retina fixes for select2 close button */
+@media  only screen and (min-device-pixel-ratio: 2),
+only screen and (min-resolution: 192dpi) {
+    .wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices a.select2-search-choice-close {
+        top: 7px;
+        left: 6px;
+    }
+}

--- a/assets/js/admin-xprofile.js
+++ b/assets/js/admin-xprofile.js
@@ -1,0 +1,82 @@
+jQuery(document).ready(function ($) {
+    $('.wc4bp-conditional-visibility-container').each(function () {
+        var $container = $(this);
+
+        $container.find('.cv-enabled input').each(function () {
+            var $checkbox = $(this);
+
+            // Reset checked status
+            $checkbox.prop('checked', $checkbox.data('checked'));
+
+            // Enable or disable search fields in response to change in checked status
+            $checkbox.change(function () {
+                if ($(this).is(":checked")) {
+                    $container.find('.wc-search').select2('readonly', false);
+                    $container.find('.field.cv-products, .field.cv-categories').removeClass('disabled');
+                } else {
+                    $container.find('.wc-search').select2('readonly', true);
+                    $container.find('.field.cv-products, .field.cv-categories').addClass('disabled');
+                }
+            });
+        });
+
+        $container.find('.wc-search').each(function () {
+            var $search = $(this);
+
+            // Reset field value
+            $search.val($search.data('value'));
+
+            // Use select2 to implement intelligent search box
+            $search.select2({
+                ajax: {
+                    url: wc4bp_admin_xprofile_params.ajax_url,
+                    dataType: 'json',
+                    quietMillis: 250,
+                    data: function (term) {
+                        return {
+                            term: term,
+                            action: $search.data('action'),
+                            security: $search.data('nonce')
+                        };
+                    },
+                    results: function (data) {
+                        var terms = [];
+                        if (data) {
+                            $.each(data, function (id, text) {
+                                terms.push({id: id, text: text});
+                            });
+                        }
+                        return {
+                            results: terms
+                        };
+                    },
+                    cache: true
+                },
+                escapeMarkup: function (m) {
+                    return m;
+                },
+                formatSelection: function (data) {
+                    return data.text;
+                },
+                initSelection: function (element, callback) {
+                    var selected = [];
+                    var data = $.parseJSON(element.attr('data-selected'));
+
+                    $(element.val().split(',')).each(function (i, val) {
+                        if (val in data) {
+                            selected.push({
+                                id: val,
+                                text: data[val]
+                            });
+                        }
+                    });
+
+                    return callback(selected);
+                },
+                minimumInputLength: 3,
+                multiple: true,
+                placeholder: $search.data('placeholder')
+            });
+        });
+    });
+});

--- a/includes/wc4bp-xprofile-data.php
+++ b/includes/wc4bp-xprofile-data.php
@@ -1,0 +1,29 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc4bp_xprofile_conditional_visibility_enabled( $object_id, $object_type ) {
+	$enabled = bp_xprofile_get_meta( $object_id, $object_type, 'bf_xprofile_conditional_visibility_enabled' );
+
+	return $enabled == '1';
+}
+
+function wc4bp_xprofile_conditional_visibility_products( $object_id, $object_type, $default = false ) {
+	$product_ids = bp_xprofile_get_meta( $object_id, $object_type, 'bf_xprofile_conditional_visibility_products' );
+	if ( empty( $product_ids ) ) {
+		return $default;
+	}
+
+	return explode( ',', $product_ids );
+}
+
+function wc4bp_xprofile_conditional_visibility_categories( $object_id, $object_type, $default = false ) {
+	$category_ids = bp_xprofile_get_meta( $object_id, $object_type, 'bf_xprofile_conditional_visibility_categories' );
+	if ( empty( $category_ids ) ) {
+		return $default;
+	}
+
+	return explode( ',', $category_ids );
+}

--- a/loader.php
+++ b/loader.php
@@ -70,8 +70,13 @@ class WC4BP_xProfile {
 
         if (is_admin()){
             require_once( plugin_dir_path( __FILE__ ) . 'admin/admin-xprofile.php');
+            require_once( plugin_dir_path( __FILE__ ) . 'admin/admin-xprofile-ajax.php');
         }
 
+    }
+
+    public static function plugin_base_url() {
+        return plugin_dir_url( __FILE__ );
     }
 
 }


### PR DESCRIPTION
This PR enhances the existing group visibility functionality with a backend UI, allowing a site admin to choose the products or categories that will cause an XProfile group to appear on the checkout page.

With this change, a 'Conditional Visibility' section will be added to each group shown on the WooCommerce BuddyPress Integration Settings page. In this section, there is a checkbox that can be used to enable/disable the feature.

The 'Conditional Visibility' section provides two WooCommerce search boxes that can be used to select the products or categories that will cause a group to appear on the checkout page. These inputs use AJAX-based searches so that configuration is as smooth as possible.

Some other notes:
- Any references to product IDs or categories that are missing (e.g. permanently deleted) will be gracefully handled/removed
- I've added `ABSPATH` checks to any new PHP files, as well as the `admin-xprofile.php` and `wc4bp-xprofile-checkout.php` files. This should probably be added to other PHP files as well.
