### PR TITLE
Fix CSS bugs in conditional visibility UI and fix warning shown when WP_DEBUG is enabled

### DIFF
--- a/admin/admin-xprofile.php
+++ b/admin/admin-xprofile.php
@@ -328,7 +328,7 @@ function buddyforms_xprofile_admin_field( $admin_field, $admin_group, $class = '
                 <input type="hidden" value="<?php echo $field->is_required; ?>" name="bf_xprofile_options[<?php echo esc_attr( $admin_group->id ); ?>][<?php echo esc_attr( $field->id ); ?>][field_is_required]">
                 <input type="hidden" value="<?php echo $field->description; ?>" name="bf_xprofile_options[<?php echo esc_attr( $admin_group->id ); ?>][<?php echo esc_attr( $field->id ); ?>][description]">
 
-                <?php if( array_search( $field->id, $billing ) || array_search( $field->id, $shipping) ) { ?>
+                <?php if( ( is_array( $billing ) && array_search( $field->id, $billing ) ) || ( is_array( $shipping ) && array_search( $field->id, $shipping) ) ) { ?>
                     <p>WooCommerce default field - Automatically Synced with BuddyPress</p>
                     Remove from Checkout: <input <?php isset($bf_xprofile_options[esc_attr( $admin_group->id )][esc_attr( $field->id )]['hide']) ? checked('hide',$bf_xprofile_options[esc_attr( $admin_group->id )][esc_attr( $field->id )]['hide']): ''; ?> type="checkbox" name="bf_xprofile_options[<?php echo esc_attr( $admin_group->id ); ?>][<?php echo esc_attr( $field->id ); ?>][hide]" value="hide">
                 <?php } else { ?>

--- a/admin/admin-xprofile.php
+++ b/admin/admin-xprofile.php
@@ -350,7 +350,11 @@ function buddyforms_xprofile_admin_field( $admin_field, $admin_group, $class = '
  * Enqueue scripts and styles that support the WooCommerce BuddyPress Integration Settings page
  */
 function wc4bp_admin_enqueue_scripts() {
-    wp_enqueue_style( 'admin-xprofile.css', WC4BP_xProfile::plugin_base_url() . 'assets/css/admin-xprofile.css' );
+
+    $wc_assets_path = str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/';
+
+    wp_enqueue_style( 'select2', $wc_assets_path . 'css/select2.css' );
+    wp_enqueue_style( 'admin-xprofile.css', WC4BP_xProfile::plugin_base_url() . 'assets/css/admin-xprofile.css', array( 'select2', 'woocommerce_admin_styles' ) );
 
     wp_register_script( 'admin-xprofile.js', WC4BP_xProfile::plugin_base_url() . 'assets/js/admin-xprofile.js',
         array( 'select2' ),  // Dependencies

--- a/assets/css/admin-xprofile.css
+++ b/assets/css/admin-xprofile.css
@@ -65,7 +65,6 @@
     margin-top: 2px;
     height: 16px;
 }
-}
 
 .wc4bp-conditional-visibility-container .fields .field .wc-search ul.select2-choices li.select2-search-field {
     font-size: 14px;


### PR DESCRIPTION
This PR is just to fix some issues that were affecting the conditional visibility UI. The first issue was caused by dependent stylesheets either not being loaded, or being loaded out of order. I've addressed that by making those dependencies explicit in wc4bp-xprofile.

The second issue was an extra closing brace in the stylesheet, which caused issues on some browsers.

While fixing this, I also noticed that a warning would be shown if wc4bp-xprofile could not retrieve billing or shipping info via `bp_get_option`. This warning is only generated while `WP_DEBUG` is enabled, but I figured that I would add an `is_array` check to fix that while I was tinkering with this code.
